### PR TITLE
Update runtime and dependencies

### DIFF
--- a/libdispatch-patches/system-blocksruntime.patch
+++ b/libdispatch-patches/system-blocksruntime.patch
@@ -1,5 +1,5 @@
---- src/CMakeLists.txt.orig	2020-05-12 13:16:34.317545662 +0300
-+++ src/CMakeLists.txt	2020-05-12 13:16:41.670936116 +0300
+--- src/CMakeLists.txt.old	2022-11-20 13:23:09.059182034 -0500
++++ src/CMakeLists.txt	2022-11-20 13:23:34.104194452 -0500
 @@ -1,8 +1,3 @@
 -
 -if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
@@ -9,13 +9,14 @@
  add_library(dispatch
    allocator.c
    apply.c
---- CMakeLists.txt.orig	2020-05-12 13:24:24.764607466 +0300
-+++ CMakeLists.txt	2020-05-12 13:24:27.634630553 +0300
-@@ -114,6 +114,7 @@
+--- CMakeLists.txt.old	2022-11-20 13:29:12.750232997 -0500
++++ CMakeLists.txt	2022-11-20 13:29:41.913235025 -0500
+@@ -147,6 +147,8 @@
+   find_package(LibRT)
  endif()
  
- find_package(LibRT)
 +find_package(BlocksRuntime)
- 
++
  check_function_exists(_pthread_workqueue_init HAVE__PTHREAD_WORKQUEUE_INIT)
  check_function_exists(getprogname HAVE_GETPROGNAME)
+ check_function_exists(mach_absolute_time HAVE_MACH_ABSOLUTE_TIME)

--- a/music.deadbeef.player-master.json
+++ b/music.deadbeef.player-master.json
@@ -2,8 +2,11 @@
     "app-id": "music.deadbeef.player",
     "branch": "master",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.38",
+    "runtime-version": "43",
     "sdk": "org.gnome.Sdk",
+    "sdk-extensions": [
+        "org.freedesktop.Sdk.Extension.llvm14"
+    ],
     "command": "deadbeef",
     "finish-args": [
         "--share=ipc",
@@ -24,6 +27,10 @@
     "rename-icon": "deadbeef",
     "rename-desktop-file": "deadbeef.desktop",
     "cleanup": [ "/include", "*.la" ],
+    "build-options": {
+        "append-path": "/usr/lib/sdk/llvm14/bin",
+        "prepend-ld-library-path": "/usr/lib/sdk/llvm14/lib"
+    },
     "modules": [
         "shared-modules/intltool/intltool-0.51.json",
         {
@@ -31,12 +38,12 @@
         },
         {
             "name": "libjansson",
-            "buildsystem": "autotools",
+            "buildsystem": "cmake",
             "sources": [
                 {
-                    "type": "archive",
-                    "url": "http://www.digip.org/jansson/releases/jansson-2.12.tar.gz",
-                    "sha256": "5f8dec765048efac5d919aded51b26a32a05397ea207aa769ff6b53c7027d2c9"
+                    "type": "git",
+                    "url": "https://github.com/akheron/jansson.git",
+                    "tag": "v2.14"
                 }
             ]
         },
@@ -58,7 +65,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/xiph/opusfile.git",
-                    "tag": "v0.11"
+                    "tag": "v0.12"
                 }
             ]
         },
@@ -126,7 +133,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/apple/swift-corelibs-libdispatch.git",
-                    "tag": "swift-5.3-RELEASE"
+                    "tag": "swift-5.7.1-RELEASE"
                 },
                 {
                     "type": "patch",

--- a/music.deadbeef.player.json
+++ b/music.deadbeef.player.json
@@ -2,8 +2,11 @@
     "app-id": "music.deadbeef.player",
     "branch": "stable",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.38",
+    "runtime-version": "43",
     "sdk": "org.gnome.Sdk",
+    "sdk-extensions": [
+        "org.freedesktop.Sdk.Extension.llvm14"
+    ],
     "command": "deadbeef",
     "finish-args": [
         "--share=ipc",
@@ -24,6 +27,10 @@
     "rename-icon": "deadbeef",
     "rename-desktop-file": "deadbeef.desktop",
     "cleanup": [ "/include", "*.la" ],
+    "build-options": {
+        "append-path": "/usr/lib/sdk/llvm14/bin",
+        "prepend-ld-library-path": "/usr/lib/sdk/llvm14/lib"
+    },
     "modules": [
         "shared-modules/intltool/intltool-0.51.json",
         {
@@ -31,12 +38,12 @@
         },
         {
             "name": "libjansson",
-            "buildsystem": "autotools",
+            "buildsystem": "cmake",
             "sources": [
                 {
-                    "type": "archive",
-                    "url": "http://www.digip.org/jansson/releases/jansson-2.12.tar.gz",
-                    "sha256": "5f8dec765048efac5d919aded51b26a32a05397ea207aa769ff6b53c7027d2c9"
+                    "type": "git",
+                    "url": "https://github.com/akheron/jansson.git",
+                    "tag": "v2.14"
                 }
             ]
         },
@@ -58,7 +65,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/xiph/opusfile.git",
-                    "tag": "v0.11"
+                    "tag": "v0.12"
                 }
             ]
         },
@@ -126,7 +133,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/apple/swift-corelibs-libdispatch.git",
-                    "tag": "swift-5.3-RELEASE"
+                    "tag": "swift-5.7.1-RELEASE"
                 },
                 {
                     "type": "patch",


### PR DESCRIPTION
org.gnome.Platform 3.38 is end-of-life, so this is updated. Updated some other dependencies as well.

Only tested on Linux.

* Update org.gnome.Platform to 43.
* Add llvm14 SDK extension (required to build with newer runtime).
* Update jansson to 2.14.
* Update opusfile to 1.12.
* Update libdispatch to 5.7.1.